### PR TITLE
Fix after YouTube update

### DIFF
--- a/css/duration-playlist.css
+++ b/css/duration-playlist.css
@@ -1,13 +1,13 @@
-#duration-block-playlist {
+.duration-block-playlist {
     margin: 10px 0px 5px 0px;
     background-color: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
-#duration-total-playlist {
+.duration-total-playlist {
     color: rgba(255, 255, 255, 1);
 }
 
-#video-counted {
+.video-counted {
     color: rgba(255, 255, 255, 1);
 }

--- a/scripts/duration-playlist.js
+++ b/scripts/duration-playlist.js
@@ -14,7 +14,7 @@ export const updateDurationPlaylist = () => {
 
     let totalTs = secondsToTs(totalSeconds);
 
-    if (document.getElementById('duration-block-playlist') === null) {
+    if (document.getElementsByClassName('duration-block-playlist').length === 0) {
         createUiELement();
         appendUiElement();
     }
@@ -26,30 +26,30 @@ const createUiELement = () => {
     // <div Outer duration block
     divDurationBlock = document.createElement("div");
     divDurationBlock.setAttribute(theme, "");
-    divDurationBlock.id = "duration-block-playlist";
-    divDurationBlock.className = "duration-block";
+    divDurationBlock.className = "duration-block duration-block-playlist";
 
     // <Span> Total:
     durationTotal = document.createElement('span');
     durationTotal.setAttribute(theme, "");
-    durationTotal.id = 'duration-total-playlist';
-    durationTotal.className = 'duration-content';
+    durationTotal.className = 'duration-content duration-total-playlist';
     durationTotal.title = "Only count video shown in the playlist panel.";
 
     // <Span> Video counted
     videoCounted = document.createElement('span');
     videoCounted.setAttribute(theme, "");
-    videoCounted.id = 'video-counted';
-    videoCounted.className = 'duration-content';
+    videoCounted.className = 'duration-content video-counted';
     videoCounted.title = "If this number not matching the total number of videos in this playlist,\nscroll down to load more video, or some videos are hidden.";
 }
 
 const appendUiElement = () => {
-    const headerContents = document.querySelector('#page-manager [page-subtype="playlist"] > ytd-playlist-header-renderer > div > div.immersive-header-content.style-scope.ytd-playlist-header-renderer > div.thumbnail-and-metadata-wrapper.style-scope.ytd-playlist-header-renderer > div > div.metadata-action-bar.style-scope.ytd-playlist-header-renderer')
+    const headerContents = document.querySelector('#page-manager [page-subtype="playlist"] .page-header-sidebar .yt-page-header-view-model__page-header-headline');
     headerContents.insertAdjacentElement('afterend', divDurationBlock);
 
     divDurationBlock.appendChild(durationTotal);
     divDurationBlock.appendChild(videoCounted);
+
+    const headerContentsMobile = document.querySelector('#page-manager [page-subtype="playlist"] #header .yt-page-header-view-model__page-header-headline');
+    headerContentsMobile.insertAdjacentElement('afterend', divDurationBlock.cloneNode(true));
 }
 
 const checkTheme = () => {
@@ -122,6 +122,13 @@ const secondsToTs = (seconds) => {
 }
 
 const updateUI = (totalTs, count) => {
-    durationTotal.innerText = "Total duration: " + totalTs;
-    videoCounted.innerText = "Videos counted: " + count;
+    const durationTotals = document.getElementsByClassName("duration-total-playlist");
+    for (const durationTotal of durationTotals) {
+        durationTotal.innerText = "Total duration: " + totalTs;
+    }
+
+    const videoCounteds = document.getElementsByClassName("video-counted");
+    for (const videoCounted of videoCounteds) {
+        videoCounted.innerText = "Videos counted: " + count;
+    }
 }


### PR DESCRIPTION
Not sure when exactly it happened, but at some point YouTube changed up some stuff with their UI, so the extension no longer works on playlist pages (it does however still work in the playlist widget on video pages). This is a quick and dirty fix to use the new class names + account for desktop and mobile now using two different header elements.

I considered creating duplicates for all the element variables so it could continue to store those without needing a lookup like the old version did, but figured that `updateUI` probably isn't called *that* often so it's probably fine to just `getElementsByClassName`. If you'd prefer the other way then I can do that, though.